### PR TITLE
Add a note about XDG_DATA_DIRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You need [bash-completion](https://github.com/scop/bash-completion) setup correc
 
 Then you can install `nix-bash-completions` from the cloned git repo with `nix-env -i -f default.nix`, or from nixpkgs eg. `nix-env -f '<nixpkgs>  -iA nix-bash-completions'`.
 
-Make sure that `$XDG_DATA_DIRS` includes `~/.nix-profile/share`, which will tell `bash-completion` where too find the script when completion is done.
+Make sure that `$XDG_DATA_DIRS` includes `~/.nix-profile/share`, which will tell `bash-completion` where to find the script when completion is done.  Be careful though: make sure that `$XDG_DATA_DIRS` also includes your distribution's defaults (like `/usr/local/share/:/usr/share/`), or you may not be able to launch some applications from the console.
 
 ### macOS
 


### PR DESCRIPTION
I am trying out Nix on Debian stable.  I set `XDG_DATA_DIRS` like this:

```
export XDG_DATA_DIRS=~/.nix-profile/share/:$XDG_DATA_DIRS
```

But apparently that wasn't sufficient.  The next day I noticed that I launching some applications from console did not work, and they gave mysterious errors like this:

```
user@host $ eog 

(eog:398): GLib-GIO-ERROR **: 09:17:43.665: No GSettings schemas are installed on the system
Trace/breakpoint trap
user@host $ geeqie 

(geeqie:538): Gdk-WARNING **: 09:17:46.822: Failed to load cursor theme DMZ-White

(geeqie:538): Gtk-WARNING **: 09:17:46.874: Could not find the icon 'folder'. The 'hicolor' theme
was not found either, perhaps you need to install it.
You can get a copy from:
	http://icon-theme.freedesktop.org/releases

(geeqie:538): Gtk-WARNING **: 09:17:46.874: Error loading theme icon 'folder' for stock: Icon 'folder' not present in theme gnome

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Could not load a pixbuf from /org/gtk/libgtk/icons/16x16/status/image-missing.png.
This may indicate that pixbuf loaders or the mime database could not be found.

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'document-open' for stock: Icon 'document-open' not present in theme gnome

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'process-stop' for stock: Icon 'process-stop' not present in theme gnome

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'go-up' for stock: Icon 'go-up' not present in theme gnome

(geeqie:538): Gtk-WARNING **: 09:17:46.875: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Aborted
```

Other people also  may encounter the same thing, and it might confuse them too.

Also fixed a small typo in the same paragraph.