### PR TITLE
Add `edit` option to nixos-rebuild

### DIFF
--- a/_nix
+++ b/_nix
@@ -783,7 +783,7 @@ function _nix_completion () {
         nixos-rebuild)
             main_commands=(
                 'switch' 'boot' 'test' 'build' 'dry-build'
-                'dry-activate' 'build-vm' 'build-vm-with-bootloader')
+                'dry-activate' 'edit' 'build-vm' 'build-vm-with-bootloader')
             _parse \
                 ${nix_boilerplate_opts[*]} \
                 ${nix_common_nixos_rebuild[*]} \


### PR DESCRIPTION
This option was missing. The commands are in the same order as the man page of `nixos-rebuild`.

I didn't test it, but I think a change this small should work! :p