### PR TITLE
Avoid completion conflict with modern 'nix' CLI

### DIFF
--- a/_nix
+++ b/_nix
@@ -1392,6 +1392,24 @@ NIX_FILE
     done
     return 1
 }
+
+# Configure 'nix' completion provider: nix>=2.4 contains its own completions,
+# prefer those.
+function _configure_modern_nix_cli_completion () {
+    local version_line versions maj_ver min_ver
+    version_line="$(nix --version || true)"
+    IFS='.' read -r -a versions <<< "${version_line##* }"
+    maj_ver="${versions[0]}"
+    min_ver="${versions[1]}"
+    if [[ "$maj_ver" -ge 2 ]] && [[ "$min_ver" -ge 4 ]]; then
+        # Nix has completion
+        source "$(dirname "$(realpath "$(command -v nix)")")"/../share/bash-completion/completions/nix
+        return
+    fi
+    # Fallback for old Nix
+    complete -F _nix_completion nix
+}
+
 # Set up the completion for all relevant commands
 complete -F _nix_completion \
           nix-build nix-shell nix-env nix-store \
@@ -1400,4 +1418,6 @@ complete -F _nix_completion \
           nix-install-package nix-prefetch-url nix-push \
           nixos-rebuild nixos-install nixos-version \
           nixos-container nixos-generate-config nixos-build-vms \
-          nix nixos-option
+          nixos-option
+
+_configure_modern_nix_cli_completion

--- a/_nix
+++ b/_nix
@@ -1397,8 +1397,10 @@ NIX_FILE
 # prefer those.
 function _configure_modern_nix_cli_completion () {
     local version_line versions maj_ver min_ver
-    version_line="$(nix --version || true)"
-    IFS='.' read -r -a versions <<< "${version_line##* }"
+    version_line=$(nix --version 2> /dev/null) || return
+    version_line=${version_line##* }
+    version_line=${version_line%%[[:alpha:]]*}
+    IFS='.' read -r -a versions <<< "$version_line"
     maj_ver="${versions[0]}"
     min_ver="${versions[1]}"
     if [[ "$maj_ver" -ge 2 ]] && [[ "$min_ver" -ge 4 ]]; then


### PR DESCRIPTION
Upstream nix (>=2.4) has completion for the modern 'nix' CLI, and the
completion provided by nix-bash-completions cause a conflict that breaks
completion:

```
  $ nix build<TAB_TAB>  # line gets erased
```

Fix it by checking the Nix version and letting Nix handle its own
completions for version >= 2.4.

Fixes https://github.com/hedning/nix-bash-completions/issues/20.