### PR TITLE
Avoid completion conflict with modern 'nix' CLI

### DIFF
--- a/_nix
+++ b/_nix
@@ -1400,4 +1400,4 @@ complete -F _nix_completion \
           nix-install-package nix-prefetch-url nix-push \
           nixos-rebuild nixos-install nixos-version \
           nixos-container nixos-generate-config nixos-build-vms \
-          nix nixos-option
+          nixos-option


### PR DESCRIPTION
[This supersedes https://github.com/hedning/nix-bash-completions/pull/21.]

Upstream nix (>=2.4) has completion for the modern 'nix' CLI, and the
completion provided by nix-bash-completions cause a conflict that breaks
completion:

  $ nix build<TAB_TAB>  # line gets erased

Fix it by not installing completion for 'nix', which lets Nix handle its
own completions.

As a side effect, this breaks/removes completion for the experimental
'nix' commands in nix<=2.3, but hopefully there is no real use case for
that anymore as even the latest NixOS version use nix>=2.8.

Fixes https://github.com/hedning/nix-bash-completions/issues/20.