### PR TITLE
Fix completion with Nix 2.4+ on non-NixOS

### DIFF
--- a/_nix
+++ b/_nix
@@ -98,7 +98,15 @@ function _nix_eval_stdin () {
     done
 
     # Eval stdin 
-    NIX_PATH=$override nix-instantiate --eval - 2> /dev/null | tr '"[]' ' '
+    if [[ -n "$override" ]]; then
+        NIX_PATH=$override nix-instantiate --eval - 2> /dev/null | tr '"[]' ' '
+    else
+        # Don't set NIX_PATH to empty string, as that'll overwrite/clear Nix'
+        # built-in default (since version 2.4+). Nix 2.3 and older sets
+        # NIX_PATH in shell initialization files, which means for those
+        # versions we already have it in $override (code path above).
+        nix-instantiate --eval - 2> /dev/null | tr '"[]' ' '
+    fi
 }
 
 # Resolve any urls ourselves, as nix will start downloading and block


### PR DESCRIPTION
Nix 2.4+ stopped setting NIX_PATH in the environment and instead uses a
built-in default in the C++ code (not exposed to shell processes). That
means this completion codes sees $override as empty and runs `NIX_PATH=
nix-instantiate ...`.
Setting NIX_PATH to an empty string means Nix
won't use its default built-in value and completion breaks (assuming
the completion depends on `<nixpkgs>` or similar search path entries).

NixOS isn't affected because there NIX_PATH is still set (by the OS, not
by code from the Nix repo).

The fix is to not pass NIX_PATH unless we have a value for it. That
works for both old and new Nix, on NixOS and non-NixOS.
