### PR TITLE
nixos-version: Add missing options

### DIFF
--- a/_nix
+++ b/_nix
@@ -810,7 +810,7 @@ function _nix_completion () {
             ;;
         nixos-version)
             _parse ${nix_boilerplate_opts[*]} \
-                   '(-*)'{--hash,--revision} && return 0
+                   '(-*)'{--hash,--revision,--configuration-revision,--json} && return 0
             ;;
         nixos-container)
             main_commands=(


### PR DESCRIPTION
`nixos-verision` was missing the `--configuration-revision` and `--json` options. I've tested the script by manually sourcing it, and everything seems fine.