### PR TITLE
Make sure `-W` argument to compgen is escaped

### DIFF
--- a/_nix
+++ b/_nix
@@ -97,8 +97,11 @@ function _nix_eval_stdin () {
         override=${override/"$url"/"$cache"}
     done
 
-    # Eval stdin 
-    NIX_PATH=$override nix-instantiate --eval - 2> /dev/null | tr '"[]' ' '
+    # Eval stdin
+    # Shortcut: since the output of this function is only used in the -W argument of compgen,
+    # which expects a shell-quoted list of words, we leave the double quotes from the Nix
+    # output intact to approximate shell quoting.
+    NIX_PATH=$override nix-instantiate --eval - 2> /dev/null | tr '[]' ' '
 }
 
 # Resolve any urls ourselves, as nix will start downloading and block
@@ -235,7 +238,7 @@ function _parse () {
     _nix_print  "    --**--" "-- Finished parsing spec"
     _nix_print  "arguments:" "${arguments[*]}"
     _nix_print "options" "${!options[*]}"
-    # _nix_print  groups: ${!groups[*]} ${groups[*]} 
+    # _nix_print  groups: ${!groups[*]} ${groups[*]}
 
 
     _nix_print  "-- Parse words"
@@ -297,7 +300,7 @@ function _parse () {
                     local prefix="${excluded_options:+|}"
                     [[ "$cword" != "$i" || $flag == -? ]] \
                         && excluded_options+="$prefix${actions[0]:0:-1}"
-                    _nix_print "$flag's exclusion group:" "$prefix${actions[0]:0:-1}" 
+                    _nix_print "$flag's exclusion group:" "$prefix${actions[0]:0:-1}"
                     actions=(${actions[*]:1})
                 fi
 
@@ -332,7 +335,7 @@ function _parse () {
     _nix_print  "-- Finished parsing words: ${completors[*]}"
 
     local completor=${completors[$cword]}
-    _nix_print  "completor: $completor" 
+    _nix_print  "completor: $completor"
 
     case "$completor" in
         -\>*)
@@ -1286,7 +1289,7 @@ NIX_FILE
                                   (import <nixpkgs> {}).lib.systems.doubles.all
 NIX_FILE
                 ))
-            COMPREPLY=($(compgen -W "${systems[*]//@(\[|\])/}" -- "$cur"))
+            COMPREPLY=($(compgen -W "${systems[*]}" -- "$cur"))
             return
             ;;
         arg-@(PATH|PATHS|NAR))


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/284162

Shell quoting is honored in the argument to `compgen -W`, which we approximate by not removing the double quotes from the Nix output.

A more robust solution would be to use `nix-instantiate --json` and parse the output with `jq -r '@sh'`, but that requires adding an external dependency.